### PR TITLE
Bump webpack-dev-server version to 3.1.14

### DIFF
--- a/css.js
+++ b/css.js
@@ -7,4 +7,8 @@ let result = sass.renderSync({
   outFile: './bin/css/coveoextension.css'
 })
 
-fs.writeFile('./bin/css/coveoextension.css', result.css);
+fs.writeFile('./bin/css/coveoextension.css', result.css, (err) => {
+  if (err) {
+    throw err;
+  }
+});

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,13 +3,17 @@ const webpackConfig = require('./webpack.config.karma.js');
 var configuration = {
     frameworks: ['jasmine'],
     files: [
-        // Both CoveoJsSearch and CoveoJsSearchTests are included as externals, so you need include them in your testing environment.
+        // CoveoJsSearch, CoveoJsSearchTests, and CoveoForDynamics are included as externals, so you need include them in your testing environment.
         {
             pattern:  'node_modules/coveo-search-ui/bin/js/CoveoJsSearch.js',
             watched: false
         },
         {
             pattern:  'node_modules/coveo-search-ui-tests/bin/js/CoveoJsSearchTests.js',
+            watched: false
+        },
+        {
+            pattern:  'node_modules/coveofordynamics-search-ui/bin/js/CoveoForDynamics.js',
             watched: false
         },
         { pattern: 'src/Index.ts' },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "2.9.1",
     "webpack": "4.12.0",
     "webpack-cli": "3.0.3",
-    "webpack-dev-server": "3.1.4",
+    "webpack-dev-server": "3.1.14",
     "yargs": "^7.1.0"
   }
 }

--- a/src/ui/HelloWorld.ts
+++ b/src/ui/HelloWorld.ts
@@ -1,4 +1,4 @@
-import { ContextObjects, ContextObject, Filters } from 'coveofordynamics-search-ui';
+import { ContextObjects, ContextObject, Crm, Filters } from 'coveofordynamics-search-ui';
 import {
   Component,
   ComponentOptions,
@@ -8,7 +8,6 @@ import {
   IBuildingQueryEventArgs,
   Initialization
 } from 'coveo-search-ui';
-import { Crm } from 'coveofordynamics-search-ui';
 import { IODataCollection } from 'coveo-odata';
 
 interface IAccount {

--- a/tests/ui/HelloWorld.spec.ts
+++ b/tests/ui/HelloWorld.spec.ts
@@ -1,6 +1,5 @@
 import { HelloWorld, IHelloWorldOptions } from '../../src/ui/HelloWorld';
-import { Mock, Fake, Simulate } from 'coveo-search-ui-tests';
-import { $$, InitializationEvents, QueryEvents, IBuildingQueryEventArgs } from 'coveo-search-ui';
+import { Mock, Simulate } from 'coveo-search-ui-tests';
 
 describe('HelloWorld', () => {
     let helloWorld: Mock.IBasicComponentSetup<HelloWorld>;


### PR DESCRIPTION
- Bumped `webpack-dev-server` to remove a security vulnerability.
- Fixed the `build` script to work with NodeJS 10. See `css.js`.
- Fixed the unit tests. See `karma.conf.js`.
